### PR TITLE
Progress so far in setup for backend in memory test queues

### DIFF
--- a/CassandraBackend.js
+++ b/CassandraBackend.js
@@ -90,8 +90,7 @@ function getTests(cb) {
         } else {
             // I'm not sure we need to have this, but it exists for now till we decide not to have it.
             for (var i = 0; i < results.rows.length; i++) {
-                test = JSON.parse(results.rows[i]);
-                this.testsList[[test.title, test.prefix].join(':')] = true;
+                this.testsList[results.rows[i]] = true;
             }
             cb(null, 0, results.rows.length);
         }

--- a/CassandraBackend.js
+++ b/CassandraBackend.js
@@ -38,25 +38,20 @@ function CassandraBackend(name, config, callback) {
 
     // Queues that we use for
     self.runningQueue = new Array();
-    self.testQueue = new Array();
 
 
-    self.testArr = [];
-    self.pq = new PriorityQueue( function(a, b) { return a.score - b.score; } );
+    self.testQueue = new PriorityQueue( function(a, b) { return a.score - b.score; } );
     self.testsList = {};
-    self.testHash = {};
 
     // Load all the tests from Cassandra - do this when we see a new commit hash
-    async.waterfall([getCommits.bind(this), getTests.bind(this), initTestPQ.bind(this)], function(err) {
+    async.waterfall([getCommits.bind( this ), getTests.bind( this ), initTestPQ.bind( this )], function(err) {
         if (err) {
             console.log( 'failure in setup', err );
         }
-        console.log( 'setup complete' );
+        console.log( 'in memory queue setup complete' );
+        console.log(self.testQueue.peek());
     });
 
-    //this.client.on('log', function(level, message) {
-    //  console.log('log event: %s -- %j', level, message);
-    //});
     callback();
 }
 
@@ -119,7 +114,7 @@ function initTestPQ(commitIndex, numTestsLeft, cb) {
         } else {
             for (var i = 0; i < results.rows.length; i++) {
                 var result = results.rows[i];
-                this.pq.enq( { test: result[0].toString(), score: result[1], commit: result[2].toString() } );
+                this.testQueue.enq( { test: result[0].toString(), score: result[1], commit: result[2].toString() } );
             }
 
             if (numTestsLeft == 0 || this.commits[commitIndex].isSnapshot) {

--- a/CassandraBackend.js
+++ b/CassandraBackend.js
@@ -98,7 +98,7 @@ function getTests(cb) {
     };
 
     // get tests
-    var cql = 'select prefix, title from tests;\n';
+    var cql = 'select prefix, title from tests;';
 
     // And finish it off
     this.client.execute(cql, [], this.consistencies.write, queryCB.bind( this ));

--- a/CassandraBackend.js
+++ b/CassandraBackend.js
@@ -68,7 +68,7 @@ function getCommits(cb) {
                 var commit = results.rows[i];
                 // commits are currently saved as blobs, we shouldn't call toString on them...
                 // commit[0].toString()
-                this.commits.push( { hash: commit[0], timestamp: commit[1], keyframe: commit[2] } );
+                this.commits.push( { hash: commit[0], timestamp: commit[1], isKeyframe: commit[2] } );
             }
             cb(null);
         }

--- a/CassandraBackend.js
+++ b/CassandraBackend.js
@@ -113,7 +113,7 @@ function initTestPQ(commitIndex, numTestsLeft, cb) {
         } else {
             for (var i = 0; i < results.rows.length; i++) {
                 var result = results.rows[i];
-                this.testQueue.enq( { test: result[0].toString(), score: result[1], commit: result[2].toString() } );
+                this.testQueue.enq( { test: result[0], score: result[1], commit: result[2].toString() } );
             }
 
             if (numTestsLeft == 0 || this.commits[commitIndex].isSnapshot) {

--- a/CassandraBackend.js
+++ b/CassandraBackend.js
@@ -8,144 +8,152 @@ var util = require('util'),
 
 // Constructor
 function CassandraBackend(name, config, callback) {
-  var self = this;
+    var self = this;
 
-  this.name = name;
-  this.config = config;
-  // convert consistencies from string to the numeric constants
-  var confConsistencies = config.backend.options.consistencies;
-  this.consistencies = {
-    read: consistencies[confConsistencies.read],
-    write: consistencies[confConsistencies.write]
-  };
+    this.name = name;
+    this.config = config;
+    // convert consistencies from string to the numeric constants
+    var confConsistencies = config.backend.options.consistencies;
+    this.consistencies = {
+        read: consistencies[confConsistencies.read],
+        write: consistencies[confConsistencies.write]
+    };
 
-  self.client = new cass.Client(config.backend.options);
+    self.client = new cass.Client(config.backend.options);
 
-  var reconnectCB = function(err) {
-    if (err) {
-      // keep trying each 500ms
-      console.error('pool connection error, scheduling retry!');
-      setTimeout(self.client.connect.bind(self.client, reconnectCB), 500);
-    }
-  };
-  this.client.on('connection', reconnectCB);
-  this.client.connect();
+    var reconnectCB = function(err) {
+        if (err) {
+            // keep trying each 500ms
+            console.error('pool connection error, scheduling retry!');
+            setTimeout(self.client.connect.bind(self.client, reconnectCB), 500);
+        }
+    };
+    this.client.on('connection', reconnectCB);
+    this.client.connect();
 
-  var numFailures = config.numFailures;
+    var numFailures = config.numFailures;
 
-  // Queues that we use for
-  self.runningQueue = new Array();
-  self.testQueue = new Array();
+    // Queues that we use for
+    self.runningQueue = new Array();
+    self.testQueue = new Array();
 
-  self.testArr = [];
-  self.testHash = {};
+    self.testArr = [];
+    self.testsList = [];
+    self.testHash = {};
 
-  // Load all the tests from Cassandra - do this when we see a new commit hash
-  getCommits = getCommits.bind(this);
-  getTests = getTests.bind(this);
-  initTestPQ = initTestPQ.bind(this);
-  async.waterfall([getCommits, getTests, initTestPQ], function(err) {
-      for (test in self.testsList) {
-          if (!(test in self.testHash)) {
-              // construct resultObj
-              var resultObj = {test: test, score: Infinity, commitIndex: -1};
-              self.testArr.push(resultObj);
-              self.testHash.push(test)
-          }
-      }
-      
-      // sort testArr by score
-      self.testArr.sort(function(a,b) {
-          return b.score - a.score;
-      });
-  });
+    // Load all the tests from Cassandra - do this when we see a new commit hash
+    getCommits = getCommits.bind(this);
+    getTests = getTests.bind(this);
+    initTestPQ = initTestPQ.bind(this);
+    async.waterfall([getCommits, getTests, initTestPQ], function(err) {
+        for (test in self.testsList) {
+            if (!(test in self.testHash)) {
+                // construct resultObj
+                var resultObj = {test: test, score: Infinity, commitIndex: -1};
+                self.testArr.push(resultObj);
+                self.testHash.push(test);
+            }
+        }
 
-  //this.client.on('log', function(level, message) {
-  //  console.log('log event: %s -- %j', level, message);
-  //});
-  callback();
+        // sort testArr by score
+        self.testArr.sort(function(a,b) {
+            return b.score - a.score;
+        });
+    });
+
+    //this.client.on('log', function(level, message) {
+    //  console.log('log event: %s -- %j', level, message);
+    //});
+    callback();
 }
 
 // cb is getTests
 function getCommits(cb) {
-	var queryCB = function (err, results) {
-			if (err) {
-				cb(err);
-			} else if (!results || !results.rows) {
-				this.commits = [];
-				cb(null);
-			} else {
-                this.commits = results.rows;
-				cb(null); 
-			}
-		};
+    console.log('in get commits');
+    var queryCB = function (err, results) {
+        if (err) {
+            console.log(err);
+            console.log('in error get commits');
+            cb(err);
+        } else if (!results || !results.rows) {
+            this.commits = [];
+            cb(null);
+        } else {
+            console.log(results.rows[0][0].toString());
+            this.commits = results.rows;
+            cb(null);
+        }
+    };
 
-  queryCB.bind(this);
-	var args = [];
+    queryCB.bind(this);
+    var args = [];
 
-	// get commits to tids
-	var cql = 'select * from commits_to_tid;\n';
-  
-	this.client.execute(cql, args, this.consistencies.write, queryCB);
+    // get commits to tids
+    var cql = 'select * from commits\n';
+    this.client.execute(cql, args, this.consistencies.write, queryCB);
 }
 
 // cb is initTestPQ
 function getTests(cb) {
-	var queryCB = function (err, results) {
-			if (err) {
-				cb(err);
-			} else if (!results || !results.rows) {
-                this.testsList = [];
-				cb(null, 0, 0);
-			} else {
-                this.testsList = testsList;
-				cb(null, 0, results.rows.length);
-			}
-		};
+    console.log('in get tests');
+    var queryCB = function (err, results) {
+        if (err) {
+            console.log('in error get tests');
+            cb(err);
+        } else if (!results || !results.rows) {
+            this.testsList = [];
+            cb(null, 0, 0);
+        } else {
+            console.log(results);
+            console.log('fail!');
+            this.testsList = results.rows;
+            cb(null, 0, results.rows.length);
+        }
+    };
 
     queryCB.bind(this);
-	var args = [];
+    var args = [];
 
-	// get tests
-	var cql = 'select * from tests;\n';
+    // get tests
+    var cql = 'select * from tests;\n';
 
-	// And finish it off
-	this.client.execute(cql, args, this.consistencies.write, queryCB);
+    // And finish it off
+    this.client.execute(cql, args, this.consistencies.write, queryCB);
 }
 
 function initTestPQ(commitIndex, numTestsLeft, cb) {
-	var queryCB = function (err, results) {
-			if (err) {
-				cb(err);
-			} else if (!results || !results.rows || results.rows.length === 0) {
-				cb(null);
-			} else {
-				for (result in results) {
-					if (!(result.test in this.testHash)) {
-						// construct resultObj
-            var resultObj = {test: test, score: score, commitIndex: commitIndex};
-						this.testArr.push(resultObj);
-            this.testHash.push(result.test)
-						numTestsLeft--;
-					}
-				}
-
-				if (numTestsLeft == 0 || this.commits[commitIndex].isSnapshot) {
-					cb(null);
-				}
-				initTestPQ(commitIndex+1, numTestsLeft, cb);
-			}
-		};
+    console.log('in init test pq');
+    var queryCB = function (err, results) {
+        if (err) {
+            console.log('in error init test PQ');
+            cb(err);
+        } else if (!results || !results.rows || results.rows.length === 0) {
+            cb(null);
+        } else {
+            for (result in results) {
+                if (!(result.test in this.testHash)) {
+                    // construct resultObj
+                    var resultObj = {test: test, score: score, commitIndex: commitIndex};
+                    this.testArr.push(resultObj);
+                    this.testHash.push(result.test)
+                    numTestsLeft--;
+                }
+            }
+            if (numTestsLeft == 0 || this.commits[commitIndex].isSnapshot) {
+                cb(null);
+            }
+            initTestPQ(commitIndex+1, numTestsLeft, cb);
+        }
+    };
 
     queryCB.bind(this);
 
-	  var lastCommit = this.commits[commitIndex].hash;
+    var lastCommit = this.commits[commitIndex].hash;
     var args = [lastCommit];
 
-	var cql = 'select (test, score, commit) from test_by_score where commit = ?';
+    var cql = 'select (test, score, commit) from test_by_score where commit = ?';
 
-	this.client.execute(cql, args, this.consistencies.write, queryCB);
-
+    this.client.execute(cql, args, this.consistencies.write, queryCB);
 }
 
 /**
@@ -196,6 +204,8 @@ CassandraBackend.prototype.getTest = function (commit, cb) {
 	// push test into running queue
 	// increment tries, return test;
     */
+    console.log('in getTest');
+    console.log(this.commits);
 	cb([ 'enwiki', 'some title', 12345 ]);
 };
 

--- a/CassandraBackend.js
+++ b/CassandraBackend.js
@@ -75,7 +75,7 @@ function getCommits(cb) {
     };
 
     // get commits to tids
-    var cql = 'select hash, tid, keyframe from commits\n';
+    var cql = 'select hash, tid, keyframe from commits';
     this.client.execute(cql, [], this.consistencies.write, queryCB.bind(this));
 }
 
@@ -90,15 +90,15 @@ function getTests(cb) {
         } else {
             // I'm not sure we need to have this, but it exists for now till we decide not to have it.
             for (var i = 0; i < results.rows.length; i++) {
-                test = results.rows[i];
-                this.testsList[[test[0], test[1]].join(':')] = true;
+                test = JSON.parse(results.rows[i]);
+                this.testsList[[test.title, test.prefix].join(':')] = true;
             }
             cb(null, 0, results.rows.length);
         }
     };
 
     // get tests
-    var cql = 'select prefix, title from tests;';
+    var cql = 'select test from tests;';
 
     // And finish it off
     this.client.execute(cql, [], this.consistencies.write, queryCB.bind( this ));

--- a/cql/create_everything.cql
+++ b/cql/create_everything.cql
@@ -22,8 +22,9 @@ CREATE TABLE IF NOT EXISTS test_by_score (
 
 -- List of tests
 CREATE TABLE IF NOT EXISTS tests (
-    test blob,
-    PRIMARY KEY (test)
+    prefix text,
+    title text,
+    PRIMARY KEY (title)
 );
 
 -- Store all of our commits with their associated timestamps.
@@ -43,3 +44,4 @@ CREATE TABLE IF NOT EXISTS pages (
     claim_num_tries int,
     PRIMARY KEY(title, prefix)
 );
+

--- a/cql/create_everything.cql
+++ b/cql/create_everything.cql
@@ -22,9 +22,8 @@ CREATE TABLE IF NOT EXISTS test_by_score (
 
 -- List of tests
 CREATE TABLE IF NOT EXISTS tests (
-    prefix text,
-    title text,
-    PRIMARY KEY (title)
+    test blob,
+    PRIMARY KEY (test)
 );
 
 -- Store all of our commits with their associated timestamps.

--- a/server.js
+++ b/server.js
@@ -198,9 +198,10 @@ var getTitle = function ( req, res ) {
 
     var fetchCb = function(err, page) {
         // 404 and 426 handling will need to be handled based upon backend return value
-        if ( !err )
+        if ( !err ) {
             console.log( ' ->', page );
             res.send( page, 200 );
+        }
     };
 
     store.getTest(commitHash, fetchCb);

--- a/server.js
+++ b/server.js
@@ -138,12 +138,6 @@ var fetchedPages = [];
 var lastFetchedCommit = null;
 var lastFetchedDate = new Date(0);
 
-// backend store needed to populate commit table?
-function populateKnownCommits( commitTable ) {
-    //Logic to populate knownCommits table goes here
-}
-
-
 var setups = {};
 setups.cassandra = function(name, options, cb) {
 	return new CassandraBackend(name, options, cb);
@@ -174,6 +168,13 @@ handlers.mock = setups.mock("", settings, function(err) {
 });
 
 /*BEGIN: COORD APP*/
+
+// // backend store needed to populate commit table?
+// function populateKnownCommits( store, commitTable ) {
+//     store.getCommits(null);
+//     //Logic to populate knownCommits table goes here
+// }
+
 /**
  * Needs to be hooked up to backend.
  */
@@ -182,19 +183,19 @@ var getTitle = function ( req, res ) {
     var commitDate = new Date( req.query.ctime );
     var knownCommit = knownCommits && knownCommits[ commitHash ];
     // init backend store reference here?
-    var store;
+    var store = handlers.cass;
 
     res.setHeader( 'Content-Type', 'text/plain; charset=UTF-8' );
 
-    if ( !knownCommit ) {
-        console.log( 'Unknown commit requested' );
-        // Maybe populate known commit table at startup?
-        // Empty commit table case handled by getTitle in current implementation
-        if ( !knownCommits ) {
-            populateKnownCommits( knownCommits );
-        }
-        // Backend logic for handling unseen commits and lastFetchedCommit goes here
-    }
+    // if ( !knownCommit ) {
+    //     console.log( 'Unknown commit requested' );
+    //     // Maybe populate known commit table at startup?
+    //     // Empty commit table case handled by getTitle in current implementation
+    //     if ( !knownCommits ) {
+    //         populateKnownCommits( store, knownCommits );
+    //     }
+    //     // Backend logic for handling unseen commits and lastFetchedCommit goes here
+    // }
 
     var fetchCb = function(err, page) {
         // 404 and 426 handling will need to be handled based upon backend return value


### PR DESCRIPTION
The following pull request is the progress Krishnan and I have made so far with the in backend memory test queues.

What we have so far:

Calling the CassandraBackend constructor will 
1. Retrieve all test names (prefix and title) from Cassandra
2. Retrieve latest test scores corresponding to retrieved test prefixes and titles
3. Order retrieved tests by placing them in a priority queue

Testing done so far:
Inserted 1 commit (commits table in schema), 2 tests (tests table in schema) and 2 tests with score (test_by_score in schema) in local Cassandra store. Ordering seems fine on the test scores in the priority queue. 

Next steps:

Find some way to insert dummy data into local Cassandra store ( Perhaps looking at how initAll.sh does it might be helpful? ) and then verify that this change behaves as expected. Once we have dummy data working progress can then be made in frontend - backend integration, test retry logic etc. 
