### PR TITLE
Basic timeout / queue logic for getTitle and addResult

### DIFF
--- a/CassandraBackend.js
+++ b/CassandraBackend.js
@@ -159,14 +159,19 @@ var removePassedTest = function(testName) {
 }
 
 var getTestToRetry() {
-    var job = this.runningQueue[this.runningQueue.length - 1];
-    if ((currTime.getMinutes() - job.startTime.getMinutes()) > 10) {
-        if (job.test.failCount < this.numFailures) {
-            job.test.failCount ++;
-            this.runningQueue.pop();
-            return job;
+    for (var i = 0; len = this.runningQueue.length; i < len; i++) {
+        var job = this.runningQueue[this.runningQueue.length - 1];
+        if ((currTime.getMinutes() - job.startTime.getMinutes()) > 10) {
+            if (job.test.failCount < this.numFailures) {
+                job.test.failCount ++;
+                this.runningQueue.pop();
+                return job;
+            } else {
+                this.runningQueue.pop();
+                // write failed test into cassandra data store
+            }
         } else {
-            // write failed test into cassandra data store
+            break;
         }
     }
     return undefined;

--- a/CassandraBackend.js
+++ b/CassandraBackend.js
@@ -148,7 +148,7 @@ CassandraBackend.prototype.getNumRegressions = function (commit, cb) {
   cb(null, fakeNum);
 };
 
-var removePassedTest = function(testName) {
+function removePassedTest(testName) {
     for (var i = 0; i < this.runningQueue.length; i++) {
         var job = this.runningQueue[i];
         if (job.test === testName) {
@@ -156,10 +156,10 @@ var removePassedTest = function(testName) {
             break;
         }
     }
-}
+};
 
-var getTestToRetry() {
-    for (var i = 0; len = this.runningQueue.length; i < len; i++) {
+function getTestToRetry() {
+    for (var i = 0, len = this.runningQueue.length; i < len; i++) {
         var job = this.runningQueue[this.runningQueue.length - 1];
         if ((currTime.getMinutes() - job.startTime.getMinutes()) > 10) {
             this.runningQueue.pop();
@@ -174,7 +174,7 @@ var getTestToRetry() {
         }
     }
     return undefined;
-}
+};
 
 /**
  * Get the next test to run

--- a/CassandraBackend.js
+++ b/CassandraBackend.js
@@ -168,7 +168,7 @@ function removePassedTest(testName) {
 };
 
 function getTestToRetry() {
-    for (var i = 0, len = this.runningQueue.length; i < len; i++) {
+    for (var i = 0, len = this.runningQueue.length, currTime = new Date(); i < len; i++) {
         var job = this.runningQueue[this.runningQueue.length - 1];
         if ((currTime.getMinutes() - job.startTime.getMinutes()) > 10) {
             this.runningQueue.pop();
@@ -204,7 +204,7 @@ CassandraBackend.prototype.getTest = function (commit, cb) {
         //ID for identifying test, containing title, prefix and oldID.
         this.runningQueue.unshift({test: test, startTime: new Date()});
 
-        cb(test);
+        cb(test.test);
     }
 
 //    cb([ 'enwiki', 'some title', 12345 ]);
@@ -261,7 +261,12 @@ CassandraBackend.prototype.addResult = function(test, commit, result, cb) {
     (removePassedTest.bind(this))(test);
     cql = 'insert into results (test, tid, result) values (?, ?, ?);';
     args = [test, tidFromDate(new Date()), result];
-    this.client.execute(cql, args, this.consistencies.write, cb);
+    this.client.execute(cql, args, this.consistencies.write, function(err, result) {
+        if (err) {
+            console.log(err);
+        } else {
+        }
+    });
     // logic to clear timeouts needs to go here
     // clearTimeout(this.runningTokens[test]);
     // var tid = commit.timestamp; // fix

--- a/CassandraBackend.js
+++ b/CassandraBackend.js
@@ -151,7 +151,7 @@ CassandraBackend.prototype.getNumRegressions = function (commit, cb) {
 var removePassedTest = function(testName) {
     for (var i = 0; i < this.runningQueue.length; i++) {
         var job = this.runningQueue[i];
-        if (job.ID === testName) {
+        if (job.test === testName) {
             this.runningQueue.splice(i, 1);
             break;
         }
@@ -162,12 +162,11 @@ var getTestToRetry() {
     for (var i = 0; len = this.runningQueue.length; i < len; i++) {
         var job = this.runningQueue[this.runningQueue.length - 1];
         if ((currTime.getMinutes() - job.startTime.getMinutes()) > 10) {
+            this.runningQueue.pop();
             if (job.test.failCount < this.numFailures) {
                 job.test.failCount ++;
-                this.runningQueue.pop();
                 return job;
             } else {
-                this.runningQueue.pop();
                 // write failed test into cassandra data store
             }
         } else {
@@ -194,10 +193,9 @@ CassandraBackend.prototype.getTest = function (commit, cb) {
     } else if (this.testQueue.size()) {
         var test = this.testQueue.deq();
         //ID for identifying test, containing title, prefix and oldID.
-        testID = JSON.parse(test.test);
-        this.runningQueue.unshift({ID: testID, test: test, startTime: new Date()});
+        this.runningQueue.unshift({test: test, startTime: new Date()});
 
-        cb(JSON.stringify({title: testID.title, prefix: testID.prefix}));
+        cb(test);
     }
 
 //    cb([ 'enwiki', 'some title', 12345 ]);

--- a/CassandraBackend.js
+++ b/CassandraBackend.js
@@ -6,6 +6,15 @@ var util = require('util'),
   PriorityQueue = require('priorityqueuejs'),
   async = require('async');
 
+function tidFromDate(date) {
+    // Create a new, deterministic timestamp
+    return uuid.v1({
+        node: [0x01, 0x23, 0x45, 0x67, 0x89, 0xab],
+        clockseq: 0x1234,
+        msecs: date.getTime(),
+        nsecs: 0
+    });
+}
 
 // Constructor
 function CassandraBackend(name, config, callback) {
@@ -250,6 +259,9 @@ CassandraBackend.prototype.getStatistics = function(cb) {
  */
 CassandraBackend.prototype.addResult = function(test, commit, result, cb) {
     (removePassedTest.bind(this))(test);
+    cql = 'insert into results (test, tid, result) values (?, ?, ?);';
+    args = [test, tidFromDate(new Date()), result];
+    this.client.execute(cql, args, this.consistencies.write, cb);
     // logic to clear timeouts needs to go here
     // clearTimeout(this.runningTokens[test]);
     // var tid = commit.timestamp; // fix

--- a/CassandraBackend.js
+++ b/CassandraBackend.js
@@ -156,7 +156,6 @@ var removePassedTest = function(testName) {
             break;
         }
     }
-    console.log(this.runningQueue);
 }
 
 /**
@@ -164,8 +163,8 @@ var removePassedTest = function(testName) {
  * and remove any test which has been running for more than 10 minutes (randomly decided number for now)
  */
 var removeFailedTests = function() {
-    for (var i = 0, currTime = new Date(); i < this.runningQueue.length; i++) {
-        var job = this.runningQueue[i];
+    for (var i = 0, currTime = new Date(), len = this.runningQueue.length; i < len; i++) {
+        var job = this.runningQueue[this.runningQueue.length - 1];
         if ((currTime.getMinutes() - job.startTime.getMinutes()) > 10) {
             if (job.test.failCount < this.numFailures) {
                 job.test.score += (job.test.failCount++ * 1000);
@@ -197,7 +196,7 @@ CassandraBackend.prototype.getTest = function (commit, cb) {
         var test = this.testQueue.deq();
         //ID for identifying test, containing title, prefix and oldID.
         testID = JSON.parse(test.test);
-        this.runningQueue.push({ID: testID, test: test, startTime: new Date()});
+        this.runningQueue.unshift({ID: testID, test: test, startTime: new Date()});
 
         // Scan running queue for failed tests
         removeFailedTests.bind(this)();

--- a/CassandraBackend.js
+++ b/CassandraBackend.js
@@ -49,9 +49,6 @@ function CassandraBackend(name, config, callback) {
             console.log( 'failure in setup', err );
         }
         console.log( 'in memory queue setup complete' );
-        if (self.testQueue.size()) {
-//            console.log(self.testQueue.peek());
-        }
     });
 
     callback();

--- a/CassandraBackend.js
+++ b/CassandraBackend.js
@@ -156,8 +156,8 @@ CassandraBackend.prototype.getNumRegressions = function (commit, cb) {
 };
 
 var testFailure = function(test) {
-    // console.log(test);
-    // console.log('failed');
+     console.log(test);
+     console.log('failed');
 };
 
 /**
@@ -174,8 +174,10 @@ CassandraBackend.prototype.getTest = function (commit, cb) {
     if (this.testQueue.size()) {
         var test = this.testQueue.deq();
         testID = JSON.parse(test.test);
-        // time to failure should be decided here, 3000 is a dummy number for now
-        this.runningTokens[testID] = setTimeout(testFailure.bind(this), 3000, test);
+
+        // time to failure should be decided here, 10000 is a dummy number for now
+        this.runningTokens[testID] = setTimeout(testFailure.bind(this), 10000, test);
+
         cb(JSON.stringify({title: testID.title, prefix: testID.prefix}));
     }
 
@@ -230,7 +232,7 @@ CassandraBackend.prototype.getStatistics = function(cb) {
  * @param cb callback (err) err or null
  */
 CassandraBackend.prototype.addResult = function(test, commit, result, cb) {
-    console.log(test);
+    clearTimeout(this.runningTokens[test]);
     // var tid = commit.timestamp; // fix
 
     // var skipCount = result.match( /<skipped/g ),

--- a/JUnitResult.js
+++ b/JUnitResult.js
@@ -1,0 +1,8 @@
+exports.parsePerfStats = function parsePerfStats(text) {
+    var regexp = /<perfstat[\s]+type="([\w\:]+)"[\s]*>([\d]+)/g;
+    var perfstats = [];
+    for ( var match = regexp.exec( text ); match !== null; match = regexp.exec( text ) ) {
+        perfstats.push( { type: match[ 1 ], value: match[ 2 ] } );
+    }
+    return perfstats;
+}

--- a/JUnitResult.js
+++ b/JUnitResult.js
@@ -6,3 +6,13 @@ exports.parsePerfStats = function parsePerfStats(text) {
     }
     return perfstats;
 }
+
+exports.getResults = function getResults(test) {
+    // This assumes that the test will still be in raw request form,
+    // If not we can just skip the test.body and pass the results in straight.
+    result = test.body.results,
+    skipCount = result.match( /<skipped/g ),
+    failCount = result.match( /<failure/g ),
+    errorCount = result.match( /<error/g );
+    return {result: result, skipCount: skipCount, failCount: failCount, errorCount: errorCount}
+}

--- a/server.js
+++ b/server.js
@@ -217,9 +217,8 @@ var receiveResults = function ( req, res ) {
     var prefix = req.params[1];
     var commitHash = req.body.commit;
     var perfstats = parsePerfStats( result );
-    console.log(result);
-    console.log(perfstats);
-    store.addResult('blah');
+    //passing in single variable to test timeout cancelling
+    store.addResult({title:title, prefix:prefix});
     res.end( 'receive results not implemented yet' );
 };
 /*END: COORD APP*/

--- a/server.js
+++ b/server.js
@@ -169,15 +169,6 @@ handlers.mock = setups.mock("", settings, function(err) {
 
 /*BEGIN: COORD APP*/
 
-// // backend store needed to populate commit table?
-// function populateKnownCommits( store, commitTable ) {
-//     store.getCommits(null);
-//     //Logic to populate knownCommits table goes here
-// }
-
-/**
- * Needs to be hooked up to backend.
- */
 var getTitle = function ( req, res ) {
     var commitHash = req.query.commit;
     var commitDate = new Date( req.query.ctime );
@@ -207,8 +198,27 @@ var getTitle = function ( req, res ) {
     store.getTest(commitHash, fetchCb);
 };
 
+var parsePerfStats = function( text ) {
+    var regexp = /<perfstat[\s]+type="([\w\:]+)"[\s]*>([\d]+)/g;
+    var perfstats = [];
+    for ( var match = regexp.exec( text ); match !== null; match = regexp.exec( text ) ) {
+        perfstats.push( { type: match[ 1 ], value: match[ 2 ] } );
+    }
+    return perfstats;
+};
+
 var receiveResults = function ( req, res ) {
     var store = handlers.cass;
+    var title = req.params[ 0 ],
+        result = req.body.results,
+        skipCount = result.match( /<skipped/g ),
+        failCount = result.match( /<failure/g ),
+        errorCount = result.match( /<error/g );
+    var prefix = req.params[1];
+    var commitHash = req.body.commit;
+    var perfstats = parsePerfStats( result );
+    console.log(result);
+    console.log(perfstats);
     store.addResult('blah');
     res.end( 'receive results not implemented yet' );
 };

--- a/server.js
+++ b/server.js
@@ -184,9 +184,7 @@ var getTitle = function ( req, res ) {
 };
 
 var receiveResults = function ( req, res ) {
-    var store = backend;
-    //passing in single variable to test timeout cancelling
-    store.addResult(req);
+    backend.addResult(req);
     res.end( 'receive results not implemented yet' );
 };
 /*END: COORD APP*/

--- a/server.js
+++ b/server.js
@@ -197,18 +197,19 @@ var getTitle = function ( req, res ) {
     //     // Backend logic for handling unseen commits and lastFetchedCommit goes here
     // }
 
-    var fetchCb = function(err, page) {
+    var fetchCb = function(page) {
+        // NOT IMPLEMENTED YET
         // 404 and 426 handling will need to be handled based upon backend return value
-        if ( !err ) {
-            console.log( ' ->', page );
-            res.send( page, 200 );
-        }
+        console.log( ' ->', page );
+        res.send( page, 200 );
     };
 
     store.getTest(commitHash, fetchCb);
 };
 
 var receiveResults = function ( req, res ) {
+    var store = handlers.cass;
+    store.addResult('blah');
     res.end( 'receive results not implemented yet' );
 };
 /*END: COORD APP*/

--- a/server.js
+++ b/server.js
@@ -183,27 +183,10 @@ var getTitle = function ( req, res ) {
     store.getTest(commitHash, fetchCb);
 };
 
-var parsePerfStats = function( text ) {
-    var regexp = /<perfstat[\s]+type="([\w\:]+)"[\s]*>([\d]+)/g;
-    var perfstats = [];
-    for ( var match = regexp.exec( text ); match !== null; match = regexp.exec( text ) ) {
-        perfstats.push( { type: match[ 1 ], value: match[ 2 ] } );
-    }
-    return perfstats;
-};
-
 var receiveResults = function ( req, res ) {
-    var store = handlers.cass;
-    var title = req.params[ 0 ],
-        result = req.body.results,
-        skipCount = result.match( /<skipped/g ),
-        failCount = result.match( /<failure/g ),
-        errorCount = result.match( /<error/g );
-    var prefix = req.params[1];
-    var commitHash = req.body.commit;
-    var perfstats = parsePerfStats( result );
+    var store = backend;
     //passing in single variable to test timeout cancelling
-    store.addResult(JSON.stringify({title:title, prefix:prefix, oldid:42}));
+    store.addResult(req);
     res.end( 'receive results not implemented yet' );
 };
 /*END: COORD APP*/

--- a/server.js
+++ b/server.js
@@ -185,7 +185,7 @@ var getTitle = function ( req, res ) {
 
 var receiveResults = function ( req, res ) {
     var test = new Buffer(JSON.stringify({title: req.params[0], prefix: req.params[1], oldid: 42}));
-    backend.addResult(test);
+    backend.addResult(test, req.body.commit, req.body.results);
     res.end( 'receive results not implemented yet' );
 };
 /*END: COORD APP*/

--- a/server.js
+++ b/server.js
@@ -218,7 +218,7 @@ var receiveResults = function ( req, res ) {
     var commitHash = req.body.commit;
     var perfstats = parsePerfStats( result );
     //passing in single variable to test timeout cancelling
-    store.addResult({title:title, prefix:prefix});
+    store.addResult(JSON.stringify({title:title, prefix:prefix, oldid:42}));
     res.end( 'receive results not implemented yet' );
 };
 /*END: COORD APP*/

--- a/server.js
+++ b/server.js
@@ -184,7 +184,8 @@ var getTitle = function ( req, res ) {
 };
 
 var receiveResults = function ( req, res ) {
-    backend.addResult(req);
+    var test = new Buffer(JSON.stringify({title: req.params[0], prefix: req.params[1], oldid: 42}));
+    backend.addResult(test);
     res.end( 'receive results not implemented yet' );
 };
 /*END: COORD APP*/

--- a/server.js
+++ b/server.js
@@ -173,16 +173,6 @@ var getTitle = function ( req, res ) {
 
     res.setHeader( 'Content-Type', 'text/plain; charset=UTF-8' );
 
-    // if ( !knownCommit ) {
-    //     console.log( 'Unknown commit requested' );
-    //     // Maybe populate known commit table at startup?
-    //     // Empty commit table case handled by getTitle in current implementation
-    //     if ( !knownCommits ) {
-    //         populateKnownCommits( store, knownCommits );
-    //     }
-    //     // Backend logic for handling unseen commits and lastFetchedCommit goes here
-    // }
-
     var fetchCb = function(page) {
         // NOT IMPLEMENTED YET
         // 404 and 426 handling will need to be handled based upon backend return value


### PR DESCRIPTION
This pull request contains the basic logic for timeouts in getTitle / addResult. 

Clients can now request jobs from the server via getTitle.

A setTimeout with on an arbitrary timeout (10000 ms for now) is called for each job handed out that should implement the job fail logic (i.e whether we would like to place the test in a separate queue, or assign it a higher score... etc). 

addResult currently just calls clearTimeout on the timeoutID corresponding to the title of the test that was just sent in.

It's set up this way because much of the schema is still very generic for now and addResults could potentially dictate how we end up handling the stats queries. It might be helpful to decide soon what we actually need to save in addResults before proceeding.
