### PR TITLE
Cassandra data loader

### DIFF
--- a/articles/importCassandra.js
+++ b/articles/importCassandra.js
@@ -1,0 +1,62 @@
+var options = {
+                hosts: [ 'localhost' ],
+                keyspace: 'testreducedb',
+                username: 'testreduce',
+                password: '',
+                poolSize: 1,
+                consistencies: { read: 'one', write: 'one' }
+              };
+
+var cql = require('node-cassandra-cql'),
+    client = new cql.Client(options);
+
+var argv = require('optimist')
+           .usage('Usage: node cassandraImport.js prefix where prefix = ar, sv... etc')
+           .demand(1)
+           .argv;
+
+//RANDOM COMMIT I MADE UP DOESN'T DO ANYTHING FOR NOW
+var DUMMYCOMMIT = '0b5db8b91bfdeb0a304b372dd8dda123b3fd1ab6';
+
+var createTestBlob = function(prefix, title) {
+    return new Buffer(JSON.stringify({prefix: prefix, title:title, oldid:42}));
+};
+
+var insertTestBlob = function(prefix, title) {
+    console.log('insert called');
+    var query = 'insert into tests (test) values (?);';
+    client.execute(query, [createTestBlob(prefix, title)], 1, function(err, result) {
+        if (err) {
+            console.log(err);
+        } else {
+        }
+    });
+};
+
+var insertTestByScore = function(prefix, title) {
+    var query = "insert into test_by_score (commit, delta, test, score) values (?, ?, ?, ?);",
+        commit = new Buffer(DUMMYCOMMIT),
+        delta = 0,
+        test = createTestBlob(prefix, title),
+        score = Math.floor(Math.random() * (10000));
+    client.execute(query, [commit, delta, test, score], 1, function(err, result) {
+        if (err) {
+            console.log(err);
+        } else {
+        }
+    });
+};
+
+var loadJSON = function(prefix) {
+    var i, titles = require(['./', prefix, 'wiki-10000.json'].join(''));
+    console.log('importing ' + prefix + ' wiki articles from:');
+    console.log(['./', prefix, 'wiki-10000.json'].join(''));
+    for (i = 0; i < titles.length; i++) {
+        console.log(prefix, titles[i]);
+        insertTestBlob(prefix, titles[i]);
+        insertTestByScore(prefix, titles[i]);
+    }
+    console.log('done importing ' + prefix + ' wiki articles');
+};
+
+loadJSON(argv['_'][0]);


### PR DESCRIPTION
Created file that mirrors importJSON slightly and allows users to load articles into Cassandra.

Some of the fields are filled with random data. (i.e the score field). But this should be a good starting point for actually loading data into Cassandra to test backend logic with real data.

Running "node importCassandra.js en" will attempt to fill the Cassandra data store with the titles in en-wiki10000.json. Verify that the data is actually loaded into cassandra by running a SELECT COUNT(*) on either the tests or test_by_score tables. Each json file contains 10000 article titles and there should be 10000 entries in your database. 
