### PR TITLE
Start of 404 and 426 implementation for getTitles

### DIFF
--- a/CassandraBackend.js
+++ b/CassandraBackend.js
@@ -212,18 +212,18 @@ CassandraBackend.prototype.updateCommits = function(lastCommitTimestamp, commit,
 CassandraBackend.prototype.getTest = function (clientCommit, clientDate, cb) {
     var retry = this.getTestToRetry(),
         lastCommitTimestamp = this.commits[0].timestamp,
-        retVal = 404;
+        retVal = { error: { code: 'ResourceNotFoundError', messsage: 'No tests to run for this commit'} };
 
     this.updateCommits(lastCommitTimestamp, clientCommit, clientDate);
     if (lastCommitTimestamp > clientDate) {
-        retVal = 426;
+        retVal = { error: { code: 'BadCommitError', message: 'Commit too old' } };
     } else if (retry) {
-        retVal = retry;
+        retVal = { test: retry };
     } else if (this.testQueue.size()) {
         var test = this.testQueue.deq();
         //ID for identifying test, containing title, prefix and oldID.
         this.runningQueue.unshift({test: test, startTime: new Date()});
-        retVal = test.test;
+        retVal = { test : test.test };
     }
     cb(retVal);
 };

--- a/CassandraBackend.js
+++ b/CassandraBackend.js
@@ -211,7 +211,7 @@ CassandraBackend.prototype.updateCommits = function(lastCommitTimestamp, commit,
  */
 CassandraBackend.prototype.getTest = function (clientCommit, clientDate, cb) {
     var retry = this.getTestToRetry(),
-        lastCommitTimestamp = this.commits[0].timestamp;
+        lastCommitTimestamp = this.commits[0].timestamp,
         retVal = 404;
 
     this.updateCommits(lastCommitTimestamp, clientCommit, clientDate);

--- a/CassandraBackend.js
+++ b/CassandraBackend.js
@@ -214,7 +214,7 @@ CassandraBackend.prototype.getTest = function (clientCommit, clientDate, cb) {
         lastCommitTimestamp = this.commits[0].timestamp;
         retVal = 404;
 
-    this.updateCommits(lastCommit, clientCommit, clientDate);
+    this.updateCommits(lastCommitTimestamp, clientCommit, clientDate);
     if (lastCommitTimestamp > clientDate) {
         retVal = 426;
     } else if (retry) {

--- a/CassandraBackend.js
+++ b/CassandraBackend.js
@@ -196,7 +196,7 @@ function getTestToRetry() {
  * JSON, for example [ 'enwiki', 'some title', 12345 ]
  */
 CassandraBackend.prototype.getTest = function (commit, cb) {
-    var retry = (getTestToRetry.bind(this))();
+    var retry = this.getTestToRetry();
     if (retry) {
         return retry;
     } else if (this.testQueue.size()) {
@@ -258,7 +258,7 @@ CassandraBackend.prototype.getStatistics = function(cb) {
  * @param cb callback (err) err or null
  */
 CassandraBackend.prototype.addResult = function(test, commit, result, cb) {
-    (removePassedTest.bind(this))(test);
+    this.removePassedTest(test);
     cql = 'insert into results (test, tid, result) values (?, ?, ?);';
     args = [test, tidFromDate(new Date()), result];
     this.client.execute(cql, args, this.consistencies.write, function(err, result) {
@@ -267,48 +267,6 @@ CassandraBackend.prototype.addResult = function(test, commit, result, cb) {
         } else {
         }
     });
-    // logic to clear timeouts needs to go here
-    // clearTimeout(this.runningTokens[test]);
-    // var tid = commit.timestamp; // fix
-
-    // var skipCount = result.match( /<skipped/g ),
-    //         failCount = result.match( /<failure/g ),
-    //         errorCount = result.match( /<error/g );
-
-    // // Build up the CQL
-    // // Simple revison table insertion only for now
-    // var cql = 'BEGIN BATCH ',
-    //     args = [],
-    // score = statsScore(skipCount, failCount, errorCount);
-
-    // // Insert into results
-    // cql += 'insert into results (test, tid, result)' +
-    //             'values(?, ?, ?);\n';
-    // args = args.concat([
-    //         test,
-    //         tid,
-    //         result
-    //     ]);
-
-    // // Check if test score changed
-    // if (testScores[test] == score) {
-    //     // If changed, update test_by_score
-    //     cq += 'insert into test_by_score (commit, score, test)' +
-    //                 'values(?, ?, ?);\n';
-    //     args = args.concat([
-    //             commit,
-    //             score,
-    //             test
-    //         ]);
-
-    //     // Update scores in memory;
-    //     testScores[test] = score;
-    // }
-    // // And finish it off
-    // cql += 'APPLY BATCH;';
-
-    // this.client.execute(cql, args, this.consistencies.write, cb);
-
 }
 
 var statsScore = function(skipCount, failCount, errorCount) {

--- a/server.js
+++ b/server.js
@@ -172,16 +172,17 @@ var getTitle = function ( req, res ) {
     res.setHeader( 'Content-Type', 'text/plain; charset=UTF-8' );
 
     var fetchCb = function(retVal) {
-        switch (retVal)
+        var errorCode = retVal.error ? retVal.error.code : undefined;
+        switch (errorCode)
         {
-            case 404:
+            case 'ResourceNotFoundError':
                 res.send('', 404);
                 break;
-            case 426:
-                res.send('', 426);
+            case 'BadCommitError':
+                res.send('', 400);
                 break;
             default:
-                res.send(retVal, 200);
+                res.send(retVal.test, 200);
                 break;
         }
     };

--- a/server.js
+++ b/server.js
@@ -165,22 +165,28 @@ if(settings.backend.type ==="cassandra") {
 /*BEGIN: COORD APP*/
 
 var getTitle = function ( req, res ) {
-    var commitHash = req.query.commit;
-    var commitDate = new Date( req.query.ctime );
-    var knownCommit = knownCommits && knownCommits[ commitHash ];
-    // init backend store reference here?
-    var store = backend;
+    var commitHash = req.query.commit,
+        commitDate = new Date(req.query.ctime),
+        store = backend;
 
     res.setHeader( 'Content-Type', 'text/plain; charset=UTF-8' );
 
-    var fetchCb = function(page) {
-        // NOT IMPLEMENTED YET
-        // 404 and 426 handling will need to be handled based upon backend return value
-        console.log( ' ->', page );
-        res.send( page, 200 );
+    var fetchCb = function(retVal) {
+        switch (retVal)
+        {
+            case 404:
+                res.send('', 404);
+                break;
+            case 426:
+                res.send('', 426);
+                break;
+            default:
+                res.send(retVal, 200);
+                break;
+        }
     };
 
-    store.getTest(commitHash, fetchCb);
+    store.getTest(commitHash, commitDate, fetchCb);
 };
 
 var receiveResults = function ( req, res ) {


### PR DESCRIPTION
This pull request begins implementation of the 404 (no titles available) and 426 (old commit, client should commit suicide) status codes in getTitle.

Old commit logic by putting an old TID into commits table and 404 tested by emptying out local Cassandra data store. 
