### PR TITLE
Front Page averages, revision summaries, histogram of fails/skips

### DIFF
--- a/CassandraBackend.js
+++ b/CassandraBackend.js
@@ -510,7 +510,7 @@ var extractESF = function (rows, cb) {
                 noerrors++;
                 noskips++;
                 nofails++;
-            } else if (data > 1000) {
+            } else if (data > 10000) {
                 noerrors++;
             } else if (data > 0) {
                 noerrors++;
@@ -585,8 +585,8 @@ CassandraBackend.prototype.addResult = function (test, commit, result, cb) {
     }
 
     if (errorCount > 0 && result.match('DoesNotExist')) {
-        console.log("Does Not Exist" + test.toString());
-        cql = 'update test_by_score set numfetcherrors = numfetcherrors + 1 where ';
+        console.log("Does Not Exist " + test.toString());
+        // cql = 'update test_by_score set numfetcherrors = numfetcherrors + 1 where ';
     }
 
 
@@ -603,14 +603,14 @@ CassandraBackend.prototype.addResult = function (test, commit, result, cb) {
 var statsScore = function (skipCount, failCount, errorCount) {
     // treat <errors,fails,skips> as digits in a base 1000 system
     // and use the number as a score which can help sort in topfails.
-    return errorCount * 1000000 + failCount * 1000 + skipCount;
+    return errorCount * 1000000 + failCount * 10000 + skipCount;
 };
 
 var countScore = function(score) {
-    var skipsCount = score % 1000;
+    var skipsCount = score % 10000;
     score = score - skipsCount;
-    var failsCount = (score % 1000000) / 1000;
-    score = score - failsCount * 1000;
+    var failsCount = (score % 1000000) / 10000;
+    score = score - failsCount * 10000;
     var errorsCount = score / 1000000;    
     
     return {skips: skipsCount, fails: failsCount, errors: errorsCount}
@@ -722,30 +722,30 @@ CassandraBackend.prototype.getSkipsDistr = function(commit, cb) {
 CassandraBackend.prototype.getFailedFetches = function(commit, cb) {
     var args = [], results = [];
 
-    var cql = "select test, numfetcherrors from test_by_score where commit = ?";
-    args = args.concat([commit]);
-    this.client.execute(cql, args, this.consistencies.write, function(err, results) {
-        if (err) {
-            console.log("err: " + err);
-            cb(err);
-        } else if (!results || !results.rows) {
-            console.log( 'no seen commits, error in database' );
-            cb(null);
-        } else {
-            //console.log("hooray we have data!: " + JSON.stringify(results, null,'\t'));
-            var failedTests = [];
-            results.rows.forEach(function(item) {
-                //console.log("item: " + JSON.stringify(item, null,'\t'));
-                var data = item[0];
-                if (data.numfetcherrors >= numFailures) {
-                    failedTests.push(data.test);
-                }
-            });
+    // var cql = "select test, numfetcherrors from test_by_score where commit = ?";
+    // args = args.concat([commit]);
+    // this.client.execute(cql, args, this.consistencies.write, function(err, results) {
+    //     if (err) {
+    //         console.log("err: " + err);
+    //         cb(err);
+    //     } else if (!results || !results.rows) {
+    //         console.log( 'no seen commits, error in database' );
+    //         cb(null);
+    //     } else {
+    //         //console.log("hooray we have data!: " + JSON.stringify(results, null,'\t'));
+    //         var failedTests = [];
+    //         results.rows.forEach(function(item) {
+    //             //console.log("item: " + JSON.stringify(item, null,'\t'));
+    //             var data = item[0];
+    //             if (data.numfetcherrors >= numFailures) {
+    //                 failedTests.push(data.test);
+    //             }
+    //         });
 
-            results = { failedTests: failedTests };
-            cb(null, results);
-        }
-    });    
+    //         results = { failedTests: failedTests };
+    //         cb(null, results);
+    //     }
+    // });    
     cb(null, results);
 }
 

--- a/CassandraBackend.js
+++ b/CassandraBackend.js
@@ -290,11 +290,7 @@ CassandraBackend.prototype.getTestToRetry = function () {
 
 CassandraBackend.prototype.updateCommits = function (lastCommitTimestamp, commit, date) {
     if (lastCommitTimestamp < date) {
-        this.commits.unshift({
-            hash: commit,
-            timestamp: date,
-            isKeyframe: false
-        });
+        var numCommits = this.commits.unshift( { hash: commit, timestamp: date, isKeyframe: false } );
         cql = 'insert into commits (hash, tid, keyframe) values (?, ?, ?);';
         args = [new Buffer(commit), tidFromDate(date), false];
         this.client.execute(cql, args, this.consistencies.write, function (err, result) {
@@ -303,15 +299,18 @@ CassandraBackend.prototype.updateCommits = function (lastCommitTimestamp, commit
             }
         });
 
-        this.getStatistics(new Buffer(commit), function (err, result) {
-            cql = 'insert into revision_summary (revision, errors, skips, fails, numtests) values (?, ? , ? , ?, ?);';
-            args = [new Buffer(commit), result.averages.errors, result.averages.skips, result.averages.fails, result.averages.numtests];
-            this.client.execute(cql, args, this.consistencies.write, function(err, result) {
-                if (err) {
-                    console.log(err);
-                }
+        if (numCommits > 1) {
+            var prevCommit = this.commits[1];
+            this.getStatistics(new Buffer(prevCommit), function (err, result) {
+                cql = 'insert into revision_summary (revision, errors, skips, fails, numtests) values (?, ? , ? , ?, ?);';
+                args = [new Buffer(prevCommit), result.averages.errors, result.averages.skips, result.averages.fails, result.averages.numtests];
+                this.client.execute(cql, args, this.consistencies.write, function(err, result) {
+                    if (err) {
+                        console.log(err);
+                    }
+                });
             });
-        });
+        }
     }
 }
 
@@ -574,9 +573,7 @@ CassandraBackend.prototype.addResult = function (test, commit, result, cb) {
     if (this.testScores[test.toString()] != score) {
         // If changed, update test_by_score
         cql = 'insert into test_by_score (commit, score, delta, test) values (?, ?, ?, ?);';
-        // args = [commit, score, this.testScores[test] - score, test];
-        args = [commit, score, 0, test];
-        
+        args = [commit, score, this.testScores[test.toString()] - score, test];        
         this.client.execute(cql, args, this.consistencies.write, function(err, result) {
             if (err) {
                 console.log(err);
@@ -586,6 +583,12 @@ CassandraBackend.prototype.addResult = function (test, commit, result, cb) {
         // Update scores in memory;
         this.testScores[test.toString()] = score;
     }
+
+    if (errorCount > 0 && result.match('DoesNotExist')) {
+        console.log("Does Not Exist" + test.toString());
+        cql = 'update test_by_score set numfetcherrors = numfetcherrors + 1 where ';
+    }
+
 
     // Update topFails
     var index = findWithAttr(this.topFailsArray, "test", test);
@@ -612,6 +615,52 @@ var countScore = function(score) {
     
     return {skips: skipsCount, fails: failsCount, errors: errorsCount}
 };
+
+function getDistr(commit, isSkips, cb) {
+    var args = [], results = {};
+
+    var cql = "select score from test_by_score where commit = ?";
+    args = args.concat([commit]);
+    this.client.execute(cql, args, this.consistencies.write, function(err, results) {
+        if (err) {
+            console.log("err: " + err);
+            cb(err);
+        } else if (!results || !results.rows) {
+            console.log( 'no seen commits, error in database' );
+            cb(null);
+        } else {
+            //console.log("hooray we have data!: " + JSON.stringify(results, null,'\t'));
+            var fails = {}, skips = {};
+            async.each(results.rows, function(item, callback) {
+                //console.log("item: " + JSON.stringify(item, null,'\t'));
+                var data = item[0];
+                var counts = countScore(data);
+                if (!isSkips) {
+                    if (!fails[counts.fails]) {
+                        fails[counts.fails] = 1;
+                    } else {
+                        fails[counts.fails]++;
+                    }                    
+                } else {
+                    if (!skips[counts.skips]) {
+                        skips[counts.skips] = 1;
+                    } else {
+                        skips[counts.skips]++;
+                    }
+                }
+                callback();
+            }, function(err) {
+                results = {
+                    fails: fails,
+                    skips: skips
+                };
+                console.log("result: " + JSON.stringify(results, null,'\t'));
+                cb(null, results);
+
+            });
+        }
+    });
+}
 
 /**
  * Get results ordered by score
@@ -660,41 +709,20 @@ CassandraBackend.prototype.getTopFails = function (offset, limit, cb) {
 }
 
 CassandraBackend.prototype.getFailsDistr = function(commit, cb) {
-    var args = [], 
-    results = {};
-
-    var cql = "select score from test_by_score where commit = ?"
-    args = args.concat([commit]);
-    this.client.execute(cql, args, this.consistencies.write, function(err, results) {
-        if (err) {
-            console.log("err: " + err);
-            cb(err);
-        } else if (!results || !results.rows) {
-            console.log( 'no seen commits, error in database' );
-            cb(null);
-        } else {
-            //console.log("hooray we have data!: " + JSON.stringify(results, null,'\t'));
-            var fails = {};
-            results.rows.forEach(function(item) {
-                var data = item[0];
-                var counts = countScore(data);
-                if (!fails[counts.fails]) {
-                    fails[counts.fails] = 1;
-                } else {
-                    fails[counts.fails]++;
-                }
-            });
-            results = {fails: fails};
-            cb(null, results);
-        }
-    });    
+    var distr = getDistr.bind(this);
+    distr(commit, false, cb);
 }
+    
 
 CassandraBackend.prototype.getSkipsDistr = function(commit, cb) {
-    var args = [], 
-    results = {};
+    var distr = getDistr.bind(this);
+    distr(commit, true, cb);    
+}
 
-    var cql = "select score from test_by_score where commit = ?"
+CassandraBackend.prototype.getFailedFetches = function(commit, cb) {
+    var args = [], results = [];
+
+    var cql = "select test, numfetcherrors from test_by_score where commit = ?";
     args = args.concat([commit]);
     this.client.execute(cql, args, this.consistencies.write, function(err, results) {
         if (err) {
@@ -705,22 +733,20 @@ CassandraBackend.prototype.getSkipsDistr = function(commit, cb) {
             cb(null);
         } else {
             //console.log("hooray we have data!: " + JSON.stringify(results, null,'\t'));
-            var skips = {};
+            var failedTests = [];
             results.rows.forEach(function(item) {
                 //console.log("item: " + JSON.stringify(item, null,'\t'));
                 var data = item[0];
-                var counts = countScore(data);
-                if (!skips[counts.skips]) {
-                    skips[counts.skips] = 1;
-                } else {
-                    skips[counts.skips]++;
+                if (data.numfetcherrors >= numFailures) {
+                    failedTests.push(data.test);
                 }
             });
 
-            results = { skips: skips };
+            results = { failedTests: failedTests };
             cb(null, results);
         }
     });    
+    cb(null, results);
 }
 
 

--- a/CassandraBackend.js
+++ b/CassandraBackend.js
@@ -404,7 +404,7 @@ CassandraBackend.prototype.getStatistics = function(commit, cb) {
                     noerrors++;
                     noskips++;
                     nofails++;
-                  } else if(data > 1000) {
+                  } else if(data > 10000) {
                     noerrors++;
                   } else if(data > 0) {
                     noerrors++;
@@ -488,8 +488,8 @@ CassandraBackend.prototype.addResult = function(test, commit, result, cb) {
     }
 
     if (errorCount > 0 && result.match('DoesNotExist')) {
-        console.log("Does Not Exist" + test.toString());
-        cql = 'update test_by_score set numfetcherrors = numfetcherrors + 1 where ';
+        console.log("Does Not Exist " + test.toString());
+        // cql = 'update test_by_score set numfetcherrors = numfetcherrors + 1 where ';
     }
 
 
@@ -507,14 +507,14 @@ CassandraBackend.prototype.addResult = function(test, commit, result, cb) {
 var statsScore = function(skipCount, failCount, errorCount) {
     // treat <errors,fails,skips> as digits in a base 1000 system
     // and use the number as a score which can help sort in topfails.
-    return errorCount*1000000+failCount*1000+skipCount;
+    return errorCount*1000000+failCount*10000+skipCount;
 };
 
 var countScore = function(score) {
-    var skipsCount = score % 1000;
+    var skipsCount = score % 10000;
     score = score - skipsCount;
-    var failsCount = (score % 1000000) / 1000;
-    score = score - failsCount * 1000;
+    var failsCount = (score % 1000000) / 10000;
+    score = score - failsCount * 10000;
     var errorsCount = score / 1000000;    
     
     return {skips: skipsCount, fails: failsCount, errors: errorsCount}
@@ -625,31 +625,31 @@ CassandraBackend.prototype.getSkipsDistr = function(commit, cb) {
 CassandraBackend.prototype.getFailedFetches = function(commit, cb) {
     var args = [], results = [];
 
-    var cql = "select test, numfetcherrors from test_by_score where commit = ?";
-    args = args.concat([commit]);
-    this.client.execute(cql, args, this.consistencies.write, function(err, results) {
-        if (err) {
-            console.log("err: " + err);
-            cb(err);
-        } else if (!results || !results.rows) {
-            console.log( 'no seen commits, error in database' );
-            cb(null);
-        } else {
-            //console.log("hooray we have data!: " + JSON.stringify(results, null,'\t'));
-            var failedTests = [];
-            async.each(results.rows, function(item, callback) {
-                //console.log("item: " + JSON.stringify(item, null,'\t'));
-                var data = item[0];
-                if (data.numfetcherrors >= numFailures) {
-                    failedTests.push(data.test);
-                }
-                callback();
-            }, function(err) {
-                console.log("result: " + JSON.stringify(failedTests, null,'\t'));
-                cb(null, results);
-            });
-        }
-    });    
+    // var cql = "select test, numfetcherrors from test_by_score where commit = ?";
+    // args = args.concat([commit]);
+    // this.client.execute(cql, args, this.consistencies.write, function(err, results) {
+    //     if (err) {
+    //         console.log("err: " + err);
+    //         cb(err);
+    //     } else if (!results || !results.rows) {
+    //         console.log( 'no seen commits, error in database' );
+    //         cb(null);
+    //     } else {
+    //         //console.log("hooray we have data!: " + JSON.stringify(results, null,'\t'));
+    //         var failedTests = [];
+    //         async.each(results.rows, function(item, callback) {
+    //             //console.log("item: " + JSON.stringify(item, null,'\t'));
+    //             var data = item[0];
+    //             if (data.numfetcherrors >= numFailures) {
+    //                 failedTests.push(data.test);
+    //             }
+    //             callback();
+    //         }, function(err) {
+    //             console.log("result: " + JSON.stringify(failedTests, null,'\t'));
+    //             cb(null, results);
+    //         });
+    //     }
+    // });    
     cb(null, results);
 }
 

--- a/cql/create_everything.cql
+++ b/cql/create_everything.cql
@@ -23,7 +23,7 @@ CREATE TABLE IF NOT EXISTS test_by_score (
 -- List of tests
 CREATE TABLE IF NOT EXISTS tests (
     test blob,
-    numfetcherrors int,
+    numDoesNotExistErrors int,
     PRIMARY KEY (test)
 );
 

--- a/cql/create_everything.cql
+++ b/cql/create_everything.cql
@@ -23,6 +23,7 @@ CREATE TABLE IF NOT EXISTS test_by_score (
 -- List of tests
 CREATE TABLE IF NOT EXISTS tests (
     test blob,
+    numfetcherrors int,
     PRIMARY KEY (test)
 );
 

--- a/server.js
+++ b/server.js
@@ -347,9 +347,34 @@ var resultWebInterface = function( req, res ) {
 };
 
 var GET_failedFetches = function( req, res ) {
-    res.write('<html><body>\n');
-    res.write('Failed fetches page go here');
-    res.end('</body></html>');
+    var fakecommit = new Buffer("0b5db8b91bfdeb0a304b372dd8dda123b3fd1ab6");
+    backend.getFailedFetches(fakecommit, function(err, result) {
+        console.log(result);
+        var n = result.length;
+        var pageData = [];
+        // console.log(result.fails);
+        for (var i = 0; i < result.length; i++) {
+            var prefix = result[i].prefix, title = result[i].title;
+            var name = prefix + ':' + title;
+            pageData.push({
+                url: prefix.replace(/wiki$/, '') + '.wikipedia.org/wiki/' + title,
+                linkName: name.replace('&', '&amp;')
+            });
+        }
+        var heading = n === 0 ? 'No titles returning 404!  All\'s well with the world!' :
+                'The following ' + n + ' titles return 404';
+
+        var data = {
+            alt: n === 0,
+            heading: heading,
+            items: pageData
+        };
+        hbs.registerHelper('formatUrl', function(url) {
+            return 'http://' + encodeURI(url).replace('&', '&amp;');
+        });
+
+        res.render('list.html', data);
+    });
 };
 
 var GET_crashers = function( req, res ) {

--- a/server.js
+++ b/server.js
@@ -347,8 +347,7 @@ var resultWebInterface = function( req, res ) {
 };
 
 var GET_failedFetches = function( req, res ) {
-    var fakecommit = new Buffer("0b5db8b91bfdeb0a304b372dd8dda123b3fd1ab6");
-    backend.getFailedFetches(fakecommit, function(err, result) {
+    backend.getFailedFetches(function(err, result) {
         console.log(result);
         var n = result.length;
         var pageData = [];

--- a/test.js
+++ b/test.js
@@ -1,0 +1,55 @@
+* BEGIN- Helper functions for GET_regressions*/
+var displayPageList = function(res, data, makeRow, err, rows){
+    console.log( "GET " + data.urlPrefix + "/" + data.page + data.urlSuffix );
+    if ( err ) {
+        res.send( err.toString(), 500 );
+    } else if ( !rows || rows.length <= 0 ) {
+        res.send( "No entries found", 404 );
+    } else {
+        var tableRows = [];
+        for (var i = 0; i < rows.length; i++) {
+            var row = rows[i];
+            var tableRow = {status: pageStatus(row), tableData: makeRow(row)};
+            // console.log("table: " + JSON.stringify(tableRow, null, '\t'));
+            tableRows.push(tableRow);
+        }
+
+        var tableData = data;
+        tableData.paginate = true;
+        tableData.row = tableRows;
+        tableData.prev = data.page > 0;
+        tableData.next = rows.length === 40;
+
+        hbs.registerHelper('prevUrl', function (urlPrefix, urlSuffix, page) {
+            return urlPrefix + "/" + ( page - 1 ) + urlSuffix;
+        });
+        hbs.registerHelper('nextUrl', function (urlPrefix, urlSuffix, page) {
+            return urlPrefix + "/" + ( page + 1 ) + urlSuffix;
+        });
+
+        // console.log("JSON: " + JSON.stringify(tableData, null, '\t'));
+        res.render('table.html', tableData);
+    }
+};
+
+var pageTitleData = function(row){
+    var parsed = JSON.parse(row.test);
+    var prefix = encodeURIComponent( parsed.prefix ),
+    title = encodeURIComponent( parsed.title );
+    return {
+        prefix: parsed.prefix,
+        title: parsed.prefix + ':' + parsed.title,
+        titleUrl: 'http://parsoid.wmflabs.org/_rt/' + prefix + '/' + title,
+        lh: 'http://localhost:8000/_rt/' + prefix + '/' + title,
+        latest: '/latestresult/' + prefix + '/' + title,
+        perf: '/pageperfstats/' + prefix + '/' + title
+    };
+};
+
+    return [
+        pageTitleData(row),
+        commitLinkData(row.new_commit, row.title, row.prefix),
+        row.errors + "|" + row.fails + "|" + row.skips,
+        commitLinkData(row.old_commit, row.title, row.prefix),
+        row.old_errors + "|" + row.old_fails + "|" + row.old_skips
+    ];

--- a/test.txt
+++ b/test.txt
@@ -1,0 +1,55 @@
+* BEGIN- Helper functions for GET_regressions*/
+var displayPageList = function(res, data, makeRow, err, rows){
+    console.log( "GET " + data.urlPrefix + "/" + data.page + data.urlSuffix );
+    if ( err ) {
+        res.send( err.toString(), 500 );
+    } else if ( !rows || rows.length <= 0 ) {
+        res.send( "No entries found", 404 );
+    } else {
+        var tableRows = [];
+        for (var i = 0; i < rows.length; i++) {
+            var row = rows[i];
+            var tableRow = {status: pageStatus(row), tableData: makeRow(row)};
+            // console.log("table: " + JSON.stringify(tableRow, null, '\t'));
+            tableRows.push(tableRow);
+        }
+
+        var tableData = data;
+        tableData.paginate = true;
+        tableData.row = tableRows;
+        tableData.prev = data.page > 0;
+        tableData.next = rows.length === 40;
+
+        hbs.registerHelper('prevUrl', function (urlPrefix, urlSuffix, page) {
+            return urlPrefix + "/" + ( page - 1 ) + urlSuffix;
+        });
+        hbs.registerHelper('nextUrl', function (urlPrefix, urlSuffix, page) {
+            return urlPrefix + "/" + ( page + 1 ) + urlSuffix;
+        });
+
+        // console.log("JSON: " + JSON.stringify(tableData, null, '\t'));
+        res.render('table.html', tableData);
+    }
+};
+
+var pageTitleData = function(row){
+    var parsed = JSON.parse(row.test);
+    var prefix = encodeURIComponent( parsed.prefix ),
+    title = encodeURIComponent( parsed.title );
+    return {
+        prefix: parsed.prefix,
+        title: parsed.prefix + ':' + parsed.title,
+        titleUrl: 'http://parsoid.wmflabs.org/_rt/' + prefix + '/' + title,
+        lh: 'http://localhost:8000/_rt/' + prefix + '/' + title,
+        latest: '/latestresult/' + prefix + '/' + title,
+        perf: '/pageperfstats/' + prefix + '/' + title
+    };
+};
+
+    return [
+        pageTitleData(row),
+        commitLinkData(row.new_commit, row.title, row.prefix),
+        row.errors + "|" + row.fails + "|" + row.skips,
+        commitLinkData(row.old_commit, row.title, row.prefix),
+        row.old_errors + "|" + row.old_fails + "|" + row.old_skips
+    ];


### PR DESCRIPTION
https://github.com/gwicke/testreduce/issues/17 : averages of skip/fail/error calculated in getStatistics, saved to revision summary table in updateCommit. Also changed the score function to be 10000*failscount.

https://github.com/gwicke/testreduce/issues/38 : finished failsDistr and skipsDistr. Finished frontend of failedFetches. Still need to figure out where to save the failed fetches info.
