### PR TITLE
More fixes to front page stats and regression/fixes

### DIFF
--- a/CassandraBackend.js
+++ b/CassandraBackend.js
@@ -55,7 +55,7 @@ function CassandraBackend(name, config, callback) {
     self.topFailsArray = [];
     self.testByScoreToCommit =[]; 
 
-    self.tasks =[getCommits.bind(this), getTests.bind(this), initTestPQ.bind(this) /*, initTopFails.bind(this)*/]; 
+    self.tasks =[getCommits.bind(this), getTests.bind(this), initTestPQ.bind(this) , initTopFails.bind(this)]; 
     // Load all the tests from Cassandra - do this when we see a new commit hash
 
     async.waterfall(self.tasks, function (err, result) {
@@ -407,7 +407,7 @@ CassandraBackend.prototype.getNumRegFix = function(cb) {
 
 
  */
- 
+
 CassandraBackend.prototype.getStatistics = function (cb) {
     var getRegFixes = this.getNumRegFix.bind(this);
     var generateStatsCB = function (err, results) {
@@ -517,31 +517,9 @@ CassandraBackend.prototype.getStatistics = function (cb) {
             else {
                 var results = {};
                 results.rows = self.testByScoreToCommit;
-                var numtests = results.rows.length;
-                getRegFixes(function (err, data) {
-                    extractESF(results.rows, function (err, ESFdata) {
-                        var averages = {
-                            errors: ESFdata.errors / numtests,
-                            fails: ESFdata.fails / numtests,
-                            skips: ESFdata.skips / numtests,
-                            score: ESFdata.totalscore / numtests,
-                            numtests: numtests
-                        }
-
-                        var results = {
-                            numtests: numtests,
-                            noerrors: ESFdata.noerrors,
-                            noskips: ESFdata.noskips,
-                            nofails: ESFdata.nofails,
-                            latestcommit: commit.toString(),
-                            beforelatestcommit: sndToLastCommit,
-                            numReg: data.reg,
-                            numFixes: data.fix,
-                            averages: averages
-                        }
-                        cb(null, results);
-                    });
-                });
+                var noQueryGen = generateStatsCB.bind(self);
+                console.log("no additional query needed");                
+                return noQueryGen(null, results);
             }
             //var results = {};
         }

--- a/MockBackend.js
+++ b/MockBackend.js
@@ -189,6 +189,7 @@ MockBackend.prototype.getStatistics = function(cb) {
     });
 }
 
+
 /**
  * getRegressionRows mock method returns the mock data of the fake regressions
  */

--- a/server.js
+++ b/server.js
@@ -229,8 +229,10 @@ var statsWebInterface = function ( req, res ) {
     numfixes
     numreg
     **/
-    var fakecommit = new Buffer("0b5db8b91bfdeb0a304b372dd8dda123b3fd1ab6");
-	backend.getStatistics(fakecommit, function(err, result) {
+
+
+	backend.getStatistics(function(err, result) {
+      if(err) return res.end("There's an error or lack of commit or testbyscore data: " + err);
 	  var tests = result.numtests;
 	  var errorLess = result.noerrors;
 	  var skipLess = result.noskips;

--- a/server.js
+++ b/server.js
@@ -505,7 +505,6 @@ var TESTGET_tfArray = function(req, res) {
     console.log("page: " + page + " numperPage: " + numperpage);
 
     backend.getTFArray(function(err, result) {
-        console.log("result: " + result[0]);
         res.end(JSON.stringify({
             err: err,
             array: result.slice(numperpage*page, numperpage*(page+1))


### PR DESCRIPTION
https://github.com/gwicke/testreduce/issues/17

Added some code so that generating front page stats won't have to do a ridiculous query again (unless needed) 

Also, if you have your database set up, you should be able to access the regression and fixes pages.

Let me know if you guys see some bugs or things I can improve on! Thanks!
